### PR TITLE
chore(coach-api): Set order of coaches to be returned by first name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build
 .idea
 dump.rdb
 .yarn/*
+install-state.gz
 !.yarn/cache
 !.yarn/patches
 !.yarn/plugins

--- a/src/services/coaches.service.ts
+++ b/src/services/coaches.service.ts
@@ -24,6 +24,7 @@ export const getCoaches = async (
       .orWhereRaw(`users.last_name ILIKE '%${search}%'`)
       .leftJoin("coach_tags", "users.id", "coach_tags.coach_id")
       .leftJoin("tags", "tags.id", "coach_tags.tag_id")
+      .orderBy("users.first_name")
       .groupBy("users.id");
 
     return searchResults;
@@ -84,6 +85,7 @@ export const getCoaches = async (
     .where("role", "coach")
     .leftJoin("coach_tags", "users.id", "coach_tags.coach_id")
     .leftJoin("tags", "tags.id", "coach_tags.tag_id")
+    .orderBy("users.first_name")
     .groupBy("users.id");
 
   return coach;


### PR DESCRIPTION
Updates the coach queries to return ordered by First name as requested by Ron, if we find we need to adjust sort orders we can make this deeper when needed.