### PR TITLE
feat(coaches): migration to style types join and clean up coaches get route, men-93

### DIFF
--- a/src/controllers/coaches.controller.ts
+++ b/src/controllers/coaches.controller.ts
@@ -9,12 +9,11 @@ import {
 } from "../services/coaches.service";
 
 export const coaches = async (req: Request, res: Response) => {
-  const { id, name, limit, search } = req.query;
+  const { id, limit, search } = req.query;
 
   try {
     const coach = await getCoaches(
       Number(id),
-      name as string,
       limit ? Number(limit) : 100,
       search as string
     );

--- a/src/database/migrations/20230320035457_alter_coach_style_types_for_users.ts
+++ b/src/database/migrations/20230320035457_alter_coach_style_types_for_users.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  return await knex.schema.alterTable("coaches_style_types", (t) => {
+    t.dropForeign("coach_id");
+    t.foreign("coach_id").references("id").inTable("users");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return await knex.schema.alterTable("coaches_style_types", (t) => {
+    t.dropForeign("coach_id");
+    t.foreign("coach_id").references("id").inTable("coaches");
+  });
+}


### PR DESCRIPTION
Run migration to point `coaches_style_types` table to users and not coaches table

GET coaches now includes style types (listed as "expertise" in the response). Manually connect a few to a user in your local db to test

Also cleaned up the GET to knock out some redundancy happening