### PR TITLE
feat(profile): coach expertise - modify post controller, Men-151

### DIFF
--- a/src/controllers/tags.controller.ts
+++ b/src/controllers/tags.controller.ts
@@ -94,10 +94,10 @@ export const deleteUserTag = async (req: Request, res: Response) => {
 };
 
 export const bulkUserTags = async (req: Request, res: Response) => {
-  const { user_id, tag_ids, clear } = req.body;
+  const { user_id, tag_ids, kind, clear } = req.body;
 
   try {
-    const userTag = await createBulkUserTags(user_id, tag_ids, clear);
+    const userTag = await createBulkUserTags(user_id, tag_ids, kind, clear);
 
     return res.json(userTag);
   } catch (error) {

--- a/src/services/tags.service.ts
+++ b/src/services/tags.service.ts
@@ -135,6 +135,7 @@ export const userTagDelete = async (id: string): Promise<Tag[] | KnexError> => {
 export const createBulkUserTags = async (
   user_id: string,
   tag_ids: number[],
+  kind: string,
   clear: boolean
 ): Promise<{ message: string }> => {
   try {
@@ -145,7 +146,10 @@ export const createBulkUserTags = async (
     }
 
     if (clear) {
-      await db("user_tag").where({ user_id }).delete();
+      await db("user_tag")
+        .join("tags", "user_tag.tag_id", "tags.id")
+        .where({ "user_tag.user_id": user_id, "tags.kind": kind })
+        .delete()
     }
 
     tag_ids.forEach(async (id: number) => {


### PR DESCRIPTION
Adjusted the `createBulkUserTags` function to account for the `kind` of tag. 

Previously, for any POST to the `user/tags` endpoint, and for any request that had the `clear` field included, all tags would be deleted for the user so that new tags could then be applied. This was a problem because if a `User` wanted to just update their `expertise` tags or their `style` tags, the other associated tags would be deleted as well. 

This change checks the `kind` of `tag` from the `req.body` and only deletes that `tag` `kind` for new `tags` to be added while leaving the other tag `kinds` undisturbed. 