### PR TITLE
fix(database): remove empty strings achievements hobbies; MEN-179

### DIFF
--- a/src/database/migrations/20230807212945_fix_empty_strings_in_achievements_hobbies.ts
+++ b/src/database/migrations/20230807212945_fix_empty_strings_in_achievements_hobbies.ts
@@ -3,21 +3,28 @@ import { User } from "../../models/users.model";
 
 export async function up(knex: Knex): Promise<void> {
   await knex.transaction(async trx => {
-    const users: User[] = await trx('users').select('id', 'achievements', 'hobbies');
+    const users: User[] = await trx('Users').select('id', 'achievements', 'hobbies');
 
     for (const user of users) {
-      const achievementsArray = user.achievements ? JSON.parse(user.achievements) : [];
-      const hobbiesArray = user.hobbies ? JSON.parse(user.hobbies) : [];
+      const updateData: Partial<User> = {};
 
-      const filteredAchievements = achievementsArray.filter((item: string) => item.trim() !== "");
-      const filteredHobbies = hobbiesArray.filter((item: string) => item.trim() !== "");
+      if (user.achievements) {
+        const achievementsArray = JSON.parse(user.achievements);
+        const filteredAchievements = achievementsArray.filter((item: string) => item.trim() !== "");
+        updateData.achievements = JSON.stringify(filteredAchievements);
+      }
 
-      await trx('users')
-        .where('id', user.id)
-        .update({
-          achievements: JSON.stringify(filteredAchievements),
-          hobbies: JSON.stringify(filteredHobbies),
-        });
+      if (user.hobbies) {
+        const hobbiesArray = JSON.parse(user.hobbies);
+        const filteredHobbies = hobbiesArray.filter((item: string) => item.trim() !== "");
+        updateData.hobbies = JSON.stringify(filteredHobbies);
+      }
+
+      if (Object.keys(updateData).length > 0) {  // Checking if there's something to update
+        await trx('Users')
+          .where('id', user.id)
+          .update(updateData);
+      }
     }
   });
 }


### PR DESCRIPTION
previously, achievements and hobbies with blank fields would be saved as empty strings in the database. This resulted in empty string entries being rendered to the front-end which would appear as blank list items. This behavior has been resolved in a[ previous PR](https://github.com/mentumm/mentumm-front-end/commit/0937de06804e4b8bd168f991803c542118f69759) so that empty string entries will never be stored for these fields.

This PR migrates the database to find all empty string entries in both the `achievements` and `hobbies` fields and remove them. This should result in no empty string entries being present in the database.