### PR TITLE
fix(search): change query builder order of operations for coach search; MEN-182

### DIFF
--- a/src/services/coaches.service.ts
+++ b/src/services/coaches.service.ts
@@ -26,8 +26,8 @@ export const getCoaches = async (
       }
       if (search) {
         qb.whereRaw(`users.first_name ILIKE '%${search}%'`);
-        qb.andWhere({ is_test: false });
         qb.orWhereRaw(`users.last_name ILIKE '%${search}%'`);
+        qb.andWhere({ is_test: false });
         qb.orderBy("users.first_name");
       }
     })


### PR DESCRIPTION
The coach search query has an inherent error after looking at the SQL it produces. The problem is that the .orWhereRaw method comes after the previous .andWhere which essentially makes the query say "...and return records where is_test is false OR the search matches a last name".

The issue is resolved by moving the `.andWhere`  method after the `.orWhereRaw`, effectively swapping the positions of those parts of the query. 