### PR TITLE
feat(coach/user): modify create+update for coach+user for retool upgrade: MEN-205

### DIFF
--- a/src/models/coaches.model.ts
+++ b/src/models/coaches.model.ts
@@ -13,6 +13,7 @@ export interface Coach {
   updated_at: Date;
   deleted_at?: Date | null;
   role?: string;
+  is_test?: boolean;
 }
 
 export interface RegisterCoach {
@@ -21,6 +22,7 @@ export interface RegisterCoach {
   email: string;
   password: string;
   invite_code: string;
+  is_test?: boolean;
 }
 
 export interface UpdateCoach {

--- a/src/models/users.model.ts
+++ b/src/models/users.model.ts
@@ -28,6 +28,7 @@ export interface User {
   website_url?: string;
   achievements: string;
   hobbies: string;
+  is_test?: boolean;
 }
 
 type UserPrivateFields =
@@ -54,6 +55,7 @@ export interface CreateUser {
   employer_id: number;
   password?: string;
   role: "coach" | "user";
+  is_test?: boolean;
 }
 
 export interface RegisterUser {

--- a/src/services/coaches.service.ts
+++ b/src/services/coaches.service.ts
@@ -41,7 +41,7 @@ export const getCoaches = async (
 export const createCoach = async (
   body: RegisterCoach
 ): Promise<Coach[] | KnexError> => {
-  const { first_name, last_name, email, password } = body;
+  const { first_name, last_name, email, password, is_test } = body;
   try {
     let errors = null;
     const lowercaseEmail = email.toLowerCase();
@@ -53,6 +53,7 @@ export const createCoach = async (
       email: lowercaseEmail,
       password: hashPassword,
       role: 'coach',
+      is_test: is_test || false,
     };
 
     const newCoach: Coach[] = await db("users")
@@ -103,6 +104,7 @@ export const updateCoach = async (
       booking_url,
       linkedin_url,
       location,
+      is_test,
     } = body;
 
     const update: User[] | KnexError = await db("users")
@@ -116,6 +118,7 @@ export const updateCoach = async (
         linkedin_url,
         location,
         updated_at: moment().toISOString(),
+        is_test: is_test || false,
       })
       .returning("*")
       .catch((err: Error) => {

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -56,7 +56,7 @@ export const createUser = async (
   body: CreateUser
 ): Promise<User[] | KnexError> => {
   try {
-    const { first_name, last_name, email, employer_id, password } = body;
+    const { first_name, last_name, email, employer_id, password, is_test } = body;
     const lowercaseEmail = email.toLowerCase();
 
     if (password) {
@@ -68,6 +68,7 @@ export const createUser = async (
         employer_id,
         password: hashPassword,
         role: "user",
+        is_test: is_test || false,
       };
 
       const newUser: User[] | { message: string } = await db("users")
@@ -90,6 +91,7 @@ export const createUser = async (
         email: lowercaseEmail,
         employer_id,
         role: "user",
+        is_test: is_test || false,
       };
 
       const newUser: User[] | { message: string } = await db("users")


### PR DESCRIPTION
A Retool update is in the works and this PR focuses on allowing users and coaches (user.role === coach) to be created and updated from retool, including all db fields currently existing. added new fields to these API requests for new columns in DB. 

Once this PR is merged, we can cut a release to Prod(main). Once that is deployed, the MEN-201 Retool upgrade can be published and should work.