### PR TITLE
fix(App): removing problematic migration step in start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "yarn install && tsc",
-    "start:prod": "yarn db:migrate && node build/index.js",
+    "start:prod": "node build/index.js",
     "start": "nodemon ./src/index.ts",
     "knex": "./node_modules/.bin/knex --knexfile src/database/knexfile.ts",
     "db:migrate": "yarn knex migrate:latest src/database/knexfile.ts",


### PR DESCRIPTION
render offers a predeploy command which is containerized with more memory than what our current plan has and runs it before deploy but after the build. 

Future work should be done to investigate why the migrate command is using over 512MB of memory when our app is small, but It is likely our use of the knex tnx, or transactions. Possible memory leak